### PR TITLE
fix #4 by clearing ORE bit, if it was set

### DIFF
--- a/WCON_SDK/WCON_Drivers/global/global_F4xx.c
+++ b/WCON_SDK/WCON_Drivers/global/global_F4xx.c
@@ -438,6 +438,9 @@ void USART1_IRQHandler()
     	WE_UART1_Internal.receivedByte = LL_USART_ReceiveData8(WE_UART1_Internal.uart);
     	(*WE_UART1_Internal.rxByteHandlerP)(&WE_UART1_Internal.receivedByte, 1);
     }
+	if (LL_USART_IsActiveFlag_ORE(WE_UART1_Internal.uart)) {
+        LL_USART_ClearFlag_ORE(WE_UART1_Internal.uart);
+    }
 #endif
 }
 
@@ -802,6 +805,9 @@ void USART6_IRQHandler()
         /* RXNE flag will be cleared by reading of DR register */
     	WE_UART6_Internal.receivedByte = LL_USART_ReceiveData8(WE_UART6_Internal.uart);
     	(*WE_UART6_Internal.rxByteHandlerP)(&WE_UART6_Internal.receivedByte, 1);
+    }
+	if (LL_USART_IsActiveFlag_ORE(WE_UART6_Internal.uart)) {
+        LL_USART_ClearFlag_ORE(WE_UART6_Internal.uart);
     }
 #endif
 }

--- a/WCON_SDK/WCON_Drivers/global/global_L0xx.c
+++ b/WCON_SDK/WCON_Drivers/global/global_L0xx.c
@@ -537,6 +537,9 @@ void USART1_IRQHandler()
     	WE_UART1_Internal.receivedByte = LL_USART_ReceiveData8(WE_UART1_Internal.uart);
     	(*WE_UART1_Internal.rxByteHandlerP)(&WE_UART1_Internal.receivedByte, 1);
     }
+	if (LL_USART_IsActiveFlag_ORE(WE_UART1_Internal.uart)) {
+        LL_USART_ClearFlag_ORE(WE_UART1_Internal.uart);
+    }
 #endif
 }
 
@@ -557,6 +560,9 @@ void USART4_5_IRQHandler()
 		WE_UART4_Internal.receivedByte = LL_USART_ReceiveData8(WE_UART4_Internal.uart);
 		(*WE_UART4_Internal.rxByteHandlerP)(&WE_UART4_Internal.receivedByte, 1);
 	}
+	if (LL_USART_IsActiveFlag_ORE(WE_UART4_Internal.uart)) {
+        LL_USART_ClearFlag_ORE(WE_UART4_Internal.uart);
+    }
 }
 
 #if defined(WE_UART_DMA)


### PR DESCRIPTION
This PR will prevent a deadlock by the uncleared ORE bit, by simply clearing that bit within the IRQ handler.
This was added to IRQ handlers in L0 and F4 implementations.


In accordance to project style, the LL Driver was used for testing and clearing the bit.